### PR TITLE
Lock setup dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,10 @@ setuptools.setup(
         "Operating System :: OS Independent",
 	],
 	install_requires = [
-		"nbformat",
-		"nbpdfexport==0.2.2",
-		"codecov",
-		"IPython"
+		"codecov==2.1.8",
+		"ipython==17.6.1"
+		"nbformat==5.0.7",
+		"nbpdfexport==0.2.1",
 	],
 	scripts=["bin/nb2pdf"]
 )


### PR DESCRIPTION
- Reverts `nbpdfexport` to `0.2.1` to remove installation errors.
- Locks dependencies to patch versions. Let me know if you would like an update to lock to minor versions only.